### PR TITLE
Fixes word wrap on buttons when using smaller screen

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -1,0 +1,3 @@
+.btn {
+    white-space: normal;
+}

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 
     <!-- Bootstrap Core CSS -->
     <link href="css/bootstrap.css" rel="stylesheet">
+    <link href="css/custom.css" rel="stylesheet">
 
     <!-- Custom Fonts -->
     <link href="font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
# What

Fixes a small issue I found when using a mobile device. Button with long names such as "Center for Undergrad Research" would not wrap correctly and would go outside the button.
# How

I added a small new custom css file (custom.css) with an overwrite from the bootstrap css.
